### PR TITLE
#74 feat: move cirricProgress to its own widget

### DIFF
--- a/Agenda-client/src/components/cirruculumProgress/CurriculumProgress.tsx
+++ b/Agenda-client/src/components/cirruculumProgress/CurriculumProgress.tsx
@@ -8,9 +8,9 @@ export const CurriculumProgress: FC<ICurriculumProgressProps> = ({
   progress = 0,
 }) => {
   return (
-    <div className="progressBar flex flex-col p-1">
-      <p className="text-[#aab8c2] text-bold pl-1">Course progress</p>
-      <h2 className="text-cw-orange font-bold pl-1">{progress}% completed</h2>
+    <div className="progressBar flex flex-col justify-between p-4">
+      <p className="text-[#aab8c2] text-bold">Course progress</p>
+      <h2 className="text-cw-orange font-bold">{progress}% completed</h2>
       <div className="progressBarContainer bg-cw-light-orange rounded-[20px]">
         <div
           className={`progressBarFiller bg-cw-orange  rounded-[20px] h-[24px]`}

--- a/Agenda-client/src/components/userProfile/UserProfile.tsx
+++ b/Agenda-client/src/components/userProfile/UserProfile.tsx
@@ -2,7 +2,6 @@ import { FC, useEffect, useState } from 'react';
 import logoutIcon from '../../assets/fi-rs-sign-out.svg';
 import IUser from '../../utils/types';
 import userData from './data/userData.json';
-import { CurriculumProgress } from '../cirruculumProgress/CurriculumProgress';
 import { createInitialsAvatar } from '../../utils/createInitialsAvatar';
 import { useNavigate } from 'react-router-dom';
 
@@ -33,12 +32,9 @@ export const UserProfile: FC = () => {
   };
 
   return user ? (
-    <div
-      data-testid="userProfile"
-      className="flex flex-col justify-around w-full h-full p-2 overflow-hidden"
-    >
-      <div className="profile flex justify-between pt-1">
-        <div className="avatar grow flex-shrink-0 pl-2">
+    <div className="profile flex justify-between w-full h-full p-4 overflow-hidden">
+      <div className="flex gap-4 justify-center items-center">
+        <div className="avatar grow flex-shrink-0">
           <img
             className="rounded-[0.5rem]"
             src={avatar}
@@ -47,23 +43,22 @@ export const UserProfile: FC = () => {
             alt="Profile"
           />
         </div>
-        <div className="userInfo text-sm flex flex-col self-end justify-center grow">
+        <div className="userInfo text-sm flex flex-col justify-center grow">
           <h2>
             {user.firstName} {user.lastName}
           </h2>
           <p>{user.email}</p>
         </div>
-        <div className="flex flex-end grow-0 shrink-0">
-          <button
-            data-testid="logoutButton"
-            className="text-white p-2 h-fit rounded-[0.5rem] bg-gradient-to-r from-cw-light-orange from-[-7%] to-cw-orange to-45% hover:bg-cw-orange active:scale-90 shadow-lg active:shadow-inner"
-            onClick={handleLogout}
-          >
-            <img src={logoutIcon} width={16} height={16} />
-          </button>
-        </div>
       </div>
-      <CurriculumProgress progress={user.cirriculumProgress} />
+      <div className="flex flex-end grow-0 shrink-0">
+        <button
+          data-testid="logoutButton"
+          className="text-white p-2 h-fit rounded-[0.5rem] bg-cw-orange hover:bg-[#eb954f] active:scale-90 shadow-lg active:shadow-inner"
+          onClick={handleLogout}
+        >
+          <img src={logoutIcon} width={16} height={16} />
+        </button>
+      </div>
     </div>
   ) : (
     <div>loading..</div>

--- a/Agenda-client/src/utils/Widget.ts
+++ b/Agenda-client/src/utils/Widget.ts
@@ -10,11 +10,12 @@ export class Widget {
 }
 
 export enum WidgetType {
-  login,
+  userProfile,
   helpRequest,
   lectureOfTheDay,
   pinnedLecture,
   announcement,
   quiz,
   calendar,
+  cirriculumProgress,
 }

--- a/Agenda-client/src/utils/componentResolver.tsx
+++ b/Agenda-client/src/utils/componentResolver.tsx
@@ -7,21 +7,27 @@ import NewHelpRequest from '../components/NewHelpRequest/NewHelpRequest';
 import Announcement from '../components/curriculum/Announcement';
 import QuizGame from '../components/QuizGame/QuizGame';
 import Calendar from '../components/Calendar/Calendar';
+import { CurriculumProgress } from '../components/cirruculumProgress/CurriculumProgress';
+import userData from '../components/userProfile/data/userData.json';
+
 export default function resolveComponent(
   componentType: WidgetType,
 
   layoutKey: string
 ) {
   const components: ComponentsMapper = {
-    [WidgetType.login]: <UserProfile />,
+    [WidgetType.userProfile]: <UserProfile />,
     [WidgetType.helpRequest]: <NewHelpRequest />,
     [WidgetType.lectureOfTheDay]: <DailyCurriculum />,
     [WidgetType.pinnedLecture]: (
       <PinnedLectureDashboardComponent layoutKey={layoutKey} />
     ),
     [WidgetType.announcement]: <Announcement />,
-    [WidgetType.quiz]: <QuizGame/>,
+    [WidgetType.quiz]: <QuizGame />,
     [WidgetType.calendar]: <Calendar />,
+    [WidgetType.cirriculumProgress]: (
+      <CurriculumProgress progress={userData.userDetails.cirriculumProgress} />
+    ),
   };
   return components[componentType] || null;
 }

--- a/Agenda-client/src/utils/layoutsDB.ts
+++ b/Agenda-client/src/utils/layoutsDB.ts
@@ -9,18 +9,19 @@ const defaultLayouts: Layouts = {
     { i: '4', x: 0, y: 2, h: 2, w: 1, isResizable: false },
     { i: '5', x: 1, y: 2, h: 2, w: 2, isResizable: false },
     { i: '6', x: 3, y: 1, h: 4, w: 1, isResizable: false },
+    { i: '7', x: 3, y: 1, h: 1, w: 1, isResizable: false },
   ],
 };
 
 const defaultWidgets: Widget[] = [
-  { i: '1', type: WidgetType.login },
+  { i: '1', type: WidgetType.userProfile },
   { i: '2', type: WidgetType.helpRequest },
   { i: '3', type: WidgetType.lectureOfTheDay },
   { i: '4', type: WidgetType.announcement },
   { i: '5', type: WidgetType.quiz },
   { i: '6', type: WidgetType.calendar },
+  { i: '7', type: WidgetType.cirriculumProgress },
 ];
-
 
 class db {
   private static instance?: db;

--- a/Agenda-client/src/utils/layoutsDB.ts
+++ b/Agenda-client/src/utils/layoutsDB.ts
@@ -9,7 +9,7 @@ const defaultLayouts: Layouts = {
     { i: '4', x: 0, y: 2, h: 2, w: 1, isResizable: false },
     { i: '5', x: 1, y: 2, h: 2, w: 2, isResizable: false },
     { i: '6', x: 3, y: 1, h: 4, w: 1, isResizable: false },
-    { i: '7', x: 3, y: 1, h: 1, w: 1, isResizable: false },
+    { i: '7', x: 0, y: 1, h: 1, w: 1, isResizable: false },
   ],
 };
 


### PR DESCRIPTION
- renamed widget `login` to `userProfile` to match the component name;
- moved cirriculumProgress to its own widget
- refactored userProfile's style
<img width="1495" alt="Screenshot 2023-12-02 at 09 10 27" src="https://github.com/itzMaffi/CW-thesis-project/assets/19465554/a80ed305-afc1-48eb-8ba7-46fd6760992c">
